### PR TITLE
feat: change scripts to prevent checksum change in yarn4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "typescript": "tsc --noEmit",
         "lint": "eslint \"src/**/*.{js,ts,tsx}\"",
         "dev": "yarn watch 'yarn prepare' ./src",
-        "prepare": "bob build"
+        "build": "bob build"
     },
     "keywords": [
         "react-native",


### PR DESCRIPTION
- The prepare script caused non-deterministic builds during install.
- Renamed to `build` for manual use before releases.
